### PR TITLE
Fix wrong dataset path when using config files to train

### DIFF
--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ def main():
     print('\n ===== RUN NAME:', run_name, f' ({save_dir}) ===== \n')
     pprint(vars(args))
 
-    dataset_path = get_dataset_path(args.dataset)
+    dataset_path = get_dataset_path(config["dataset"])
 
     wandb.init(config=config,
                name=run_name,

--- a/train.py
+++ b/train.py
@@ -103,8 +103,7 @@ def main():
     print('\n ===== RUN NAME:', run_name, f' ({save_dir}) ===== \n')
     pprint(vars(args))
 
-    dataset_path = get_dataset_path(config["dataset"])
-
+    dataset_path = get_dataset_path(config["dataset"] if "dataset" in config and "--dataset" not in sys.argv else args.dataset)
     wandb.init(config=config,
                name=run_name,
                group=args.group,


### PR DESCRIPTION
When using config file to train, [line here](https://github.com/gabrieletiboni/paintnet/blob/ec07313526ea6b6a314dba35116b5f3e58aec456/train.py#L106) will always load dataset using the default value of `--dataset`, which can be different from the dataset defined in config file.

Changes make sure loading dataset defined in config file only when 'dataset' exists in config file and '--dataset' is not set by user.